### PR TITLE
Renaming framebuffer methods

### DIFF
--- a/samples/asteroids/asteroids.rb
+++ b/samples/asteroids/asteroids.rb
@@ -11,17 +11,17 @@ Engine.start(base_dir: File.dirname(__FILE__)) do
 
   Engine::GameObject.new(
     "Camera",
-    pos: Vector[Engine.screen_width / 2, Engine.screen_height / 2, 0],
+    pos: Vector[Engine::Window.framebuffer_width / 2, Engine::Window.framebuffer_height / 2, 0],
     components: [
       Engine::Components::OrthographicCamera.new(
-        width: Engine.screen_width, height: Engine.screen_height, far: 1000
+        width: Engine::Window.framebuffer_width, height: Engine::Window.framebuffer_height, far: 1000
       )
     ]
   )
 
   10.times do
     Asteroid.create(
-      Vector[rand(Engine.screen_width), rand(Engine.screen_height), 0],
+      Vector[rand(Engine::Window.framebuffer_width), rand(Engine::Window.framebuffer_height), 0],
       rand(360),
       rand(50..100)
     )

--- a/samples/asteroids/components/clamp_to_screen.rb
+++ b/samples/asteroids/components/clamp_to_screen.rb
@@ -9,15 +9,15 @@ module Asteroids
     private
 
     def clamp_to_screen
-      if game_object.x > Engine.screen_width
+      if game_object.x > Engine::Window.framebuffer_width
         game_object.x = 0
       elsif game_object.x < 0
-        game_object.x = Engine.screen_width
+        game_object.x = Engine::Window.framebuffer_width
       end
-      if game_object.y > Engine.screen_height
+      if game_object.y > Engine::Window.framebuffer_height
         game_object.y = 0
       elsif game_object.y < 0
-        game_object.y = Engine.screen_height
+        game_object.y = Engine::Window.framebuffer_height
       end
     end
   end

--- a/samples/asteroids/components/fps_component.rb
+++ b/samples/asteroids/components/fps_component.rb
@@ -21,6 +21,9 @@ module Asteroids
         "FPS: #{Engine.fps.round(4)}",
         "Total Game Objects: #{Engine::GameObject.objects.count}",
         "",
+        "Window: #{Engine::Window.height} x #{Engine::Window.width}",
+        "FrameBuffer: #{Engine::Window.framebuffer_height} x #{Engine::Window.framebuffer_width}",
+        "",
         "#{game_objects_tallied}"
       ].join("\n")
     end

--- a/spec/samples/cubes/game_objects/teapot_spec.rb
+++ b/spec/samples/cubes/game_objects/teapot_spec.rb
@@ -14,9 +14,9 @@ describe Cubes::Teapot do
       within_game_context(load_path: "./samples/cubes") do
         at(0) do
           Engine::GameObject.new(
-            "Camera", pos: Vector[Engine.screen_width / 2, Engine.screen_height / 2, 1000],
+            "Camera", pos: Vector[Engine::Window.framebuffer_width / 2, Engine::Window.framebuffer_height / 2, 1000],
             components: [
-              Engine::Components::OrthographicCamera.new(width: Engine.screen_width, height: Engine.screen_height, far: 2000)
+              Engine::Components::OrthographicCamera.new(width: Engine::Window.framebuffer_width, height: Engine::Window.framebuffer_height, far: 2000)
             ]
           )
           Cubes::Teapot.create(Vector[500, 500], Vector[43, 68, 38], 500)
@@ -37,16 +37,16 @@ describe Cubes::Teapot do
         at(0) do
           Cubes::Teapot.create(Vector[100, 100], Vector[43, 68, 38], 500)
           Engine::GameObject.new(
-            "light", pos: Vector[Engine.screen_width / 2, 500, 100], components: [
+            "light", pos: Vector[Engine::Window.framebuffer_width / 2, 500, 100], components: [
             Engine::Components::PointLight.new(
               range: 300,
               colour: Vector[0.5, 0.5, 0.5],
             )
           ])
           Engine::GameObject.new(
-            "Camera", pos: Vector[Engine.screen_width / 2, Engine.screen_height / 2, 1000],
+            "Camera", pos: Vector[Engine::Window.framebuffer_width / 2, Engine::Window.framebuffer_height / 2, 1000],
             components: [
-              Engine::Components::PerspectiveCamera.new(fov: 45.0, aspect: Engine.screen_width / Engine.screen_height, near: 0.1, far: 2000)
+              Engine::Components::PerspectiveCamera.new(fov: 45.0, aspect: Engine::Window.framebuffer_width / Engine::Window.framebuffer_height, near: 0.1, far: 2000)
             ]
           )
         end

--- a/src/engine/components/rect_renderer.rb
+++ b/src/engine/components/rect_renderer.rb
@@ -46,8 +46,8 @@ module Engine::Components
 
     def set_shader_camera_matrix
       shader.set_mat4("camera", [
-        2.0 / Engine.screen_width, 0, 0, 0,
-        0, 2.0 / Engine.screen_height, 0, 0,
+        2.0 / Engine::Window.framebuffer_width, 0, 0, 0,
+        0, 2.0 / Engine::Window.framebuffer_height, 0, 0,
         0, 0, 1, 0,
         -1, -1, 0, 1
       ])

--- a/src/engine/components/triangle_renderer.rb
+++ b/src/engine/components/triangle_renderer.rb
@@ -45,8 +45,8 @@ module Engine::Components
 
     def set_shader_camera_matrix
       shader.set_mat4("camera", [
-        2.0 / Engine.screen_width, 0, 0, 0,
-        0, 2.0 / Engine.screen_height, 0, 0,
+        2.0 / Engine::Window.framebuffer_width, 0, 0, 0,
+        0, 2.0 / Engine::Window.framebuffer_height, 0, 0,
         0, 0, 1, 0,
         -1, -1, 0, 1
       ])

--- a/src/engine/components/ui_font_renderer.rb
+++ b/src/engine/components/ui_font_renderer.rb
@@ -60,8 +60,8 @@ module Engine::Components
 
     def set_shader_camera_matrix
       camera_matrix = Matrix[
-        [2.0 / Engine.screen_width, 0, 0, 0],
-        [0, 2.0 / Engine.screen_height, 0, 0],
+        [2.0 / Engine::Window.framebuffer_width, 0, 0, 0],
+        [0, 2.0 / Engine::Window.framebuffer_height, 0, 0],
         [0, 0, 1, 0],
         [-1, -1, 0, 1]
       ]

--- a/src/engine/components/ui_sprite_renderer.rb
+++ b/src/engine/components/ui_sprite_renderer.rb
@@ -44,8 +44,8 @@ module Engine::Components
 
     def set_camera_matrix
       camera_matrix = Matrix[
-        [2.0 / Engine.screen_width, 0, 0, 0],
-        [0, 2.0 / Engine.screen_height, 0, 0],
+        [2.0 / Engine::Window.framebuffer_width, 0, 0, 0],
+        [0, 2.0 / Engine::Window.framebuffer_height, 0, 0],
         [0, 0, 1, 0],
         [-1, -1, 0, 1]
       ]

--- a/src/engine/engine.rb
+++ b/src/engine/engine.rb
@@ -205,14 +205,6 @@ module Engine
     end
   end
 
-  def self.screen_width
-    Window.screen_width
-  end
-
-  def self.screen_height
-    Window.screen_height
-  end
-
   def self.debug_opengl_call
     errors = []
     until GL.GetError == 0; end

--- a/src/engine/engine.rb
+++ b/src/engine/engine.rb
@@ -95,7 +95,7 @@ module Engine
     @old_time = Time.now
     @time = Time.now
     @fps = 0
-    Window.update_screen_size
+    Window.get_framebuffer_size
     GL.Clear(GL::COLOR_BUFFER_BIT | GL::DEPTH_BUFFER_BIT)
 
     until GLFW.WindowShouldClose(Window.window) == GLFW::TRUE || @game_stopped
@@ -125,7 +125,7 @@ module Engine
         Screenshoter.take_screenshot
       end
 
-      Window.update_screen_size
+      Window.get_framebuffer_size
 
       if OS.windows?
         GLFW.SwapBuffers(Window.window)

--- a/src/engine/screenshoter.rb
+++ b/src/engine/screenshoter.rb
@@ -10,8 +10,8 @@ module Engine
 
     def self.take_screenshot
       @scheduled_screenshot = nil
-      width = Engine.screen_width
-      height = Engine.screen_height
+      width = Engine::Window.framebuffer_width
+      height = Engine::Window.framebuffer_height
       pixels = ' ' * (width * height * 3)
       GL.ReadPixels(0, 0, width, height, GL::RGB, GL::UNSIGNED_BYTE, pixels)
       png = ChunkyPNG::Image.new(width, height, ChunkyPNG::Color::TRANSPARENT)

--- a/src/engine/window.rb
+++ b/src/engine/window.rb
@@ -95,7 +95,7 @@ module Engine
         GLFW.FocusWindow(window)
       end
 
-      def update_screen_size
+      def get_framebuffer_size
         width_buf = ' ' * 8
         height_buf = ' ' * 8
 

--- a/src/engine/window.rb
+++ b/src/engine/window.rb
@@ -11,6 +11,7 @@ module Engine
 
     class << self
       attr_accessor :full_screen, :window, :window_title
+      attr_reader :framebuffer_height, :framebuffer_width
 
       def create_window(window_title: 'Ruby RPG')
         @full_screen = FULL_SCREEN
@@ -99,16 +100,8 @@ module Engine
         height_buf = ' ' * 8
 
         GLFW.GetFramebufferSize(window, width_buf, height_buf)
-        @screen_width = width_buf.unpack('L')[0]
-        @screen_height = height_buf.unpack('L')[0]
-      end
-
-      def screen_width
-        @screen_width
-      end
-
-      def screen_height
-        @screen_height
+        @framebuffer_width = width_buf.unpack1('L')
+        @framebuffer_height = height_buf.unpack1('L')
       end
 
       def set_opengl_version


### PR DESCRIPTION
# What
- Renaming `Engine.screen_{height,width}` -> `Window.framebuffer_{height,width}`:
    Dropped `Engine.screen_{height,width}` since it was just pointing to `Window.screen_{height,width}`.
    `Window.screen_{height,width}` is actually `framebuffer_{height,width}`, so I've updated this throughout accordingly, and made them `attr_reader`s on `Engine::Window`.
- Added window and framebuffer dimensions to Asteroids onscreen debugger:
    This helps demonstrate the difference between framebuffer dimensions and window dimensions.
- Renaming `update_screen_size` -> `get_framebuffer_size`
    More accurately reflects what the method is doing.

Setting things up for:
- #18