### PR TITLE
Adding support for automatically determining video modes

### DIFF
--- a/src/engine/engine.rb
+++ b/src/engine/engine.rb
@@ -21,6 +21,7 @@ require_relative 'shader'
 require_relative 'component'
 require_relative "camera"
 require_relative "window"
+require_relative "video_mode"
 require_relative "cursor"
 
 require_relative "components/orthographic_camera"

--- a/src/engine/video_mode.rb
+++ b/src/engine/video_mode.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Engine
+  # https://www.glfw.org/docs/latest/struct_g_l_f_wvidmode.html
+  # https://www.glfw.org/docs/latest/monitor_guide.html#monitor_modes
+  class VideoMode
+    class << self
+      def current_video_mode(monitor: Window.primary_monitor)
+        video_mode_helper(GLFW.GetVideoMode(monitor), 0)
+      end
+
+      # Returns an array of video modes
+      def get_video_modes(monitor: Window.primary_monitor)
+        count_pointer = ' ' * Fiddle::SIZEOF_INT
+        modes_pointer = GLFW.GetVideoModes(monitor, count_pointer)
+        count = count_pointer.unpack1('L')
+
+        supported_video_modes = []
+        count.times do |i|
+          supported_video_modes << video_mode_helper(modes_pointer, i)
+        end
+        supported_video_modes
+      end
+
+      def print_video_mode(mode)
+        GLFW::GLFWvidmode.members.map(&:to_sym).map do |attr|
+          puts "#{attr}: #{mode.send(attr)}"
+        end
+        puts
+      end
+
+      def video_mode_helper(mode_pointer, index)
+        GLFW::GLFWvidmode.new(mode_pointer + index * GLFW::GLFWvidmode.size)
+      end
+    end
+  end
+end

--- a/src/engine/window.rb
+++ b/src/engine/window.rb
@@ -3,32 +3,33 @@
 module Engine
   class Window
 
-    FULL_SCREEN       = true
-    MAX_WIDTH         = 1920
-    MAX_HEIGHT        = 1080
-    WINDOWED_WIDTH    = 1200
-    WINDOWED_HEIGHT   = 800
+    DEFAULT_TITLE = File.basename($PROGRAM_NAME).gsub(/\.rb$/,'')
 
     class << self
       attr_accessor :full_screen, :window, :window_title
       attr_reader :framebuffer_height, :framebuffer_width
 
-      def create_window(window_title: 'Ruby RPG')
-        @full_screen = FULL_SCREEN
+      def create_window
         set_opengl_version
         enable_decorations
         disable_auto_iconify
-        @window = GLFW.CreateWindow(width, height, window_title, monitor, nil)
+        @full_screen = true
+        initial_video_mode = VideoMode.current_video_mode
+        @window = GLFW.CreateWindow(
+          initial_video_mode.width, initial_video_mode.height, DEFAULT_TITLE, primary_monitor, nil
+        )
       end
 
       alias full_screen? full_screen
 
       def width
-        @width = full_screen? ? MAX_WIDTH : WINDOWED_WIDTH
+        max_width = VideoMode.current_video_mode.width
+        @width = full_screen? ? max_width : max_width * 0.8
       end
 
       def height
-        @height = full_screen? ? MAX_HEIGHT : WINDOWED_HEIGHT
+        max_height = VideoMode.current_video_mode.height
+        @height = full_screen? ? max_height : max_height * 0.8
       end
 
       def monitor


### PR DESCRIPTION
# What
Adding `Engine::VideoMode` to handle:
- determining the current video mode (default to the primary monitor)
- determining all supported video modes (again defaults to the primary monitor)
- use the current video mode to:
  - set the default window size
  - determine the windowed size (80% of full screen)
- automatically determine window title from `$PROGRAM_NAME` (e.g. `asteroid`, `shrink_racer`)

To make things easier, default to full screen enabled, and use the toggle, `F` key, to switch between windowed and full screen. This means we can get rid of the global vars.

## Example
This can be used to print the current video mode and all supported video modes:
``` ruby
puts "Current Video Mode:"
VideoMode.print_video_mode(VideoMode.current_video_mode)

puts "All Supported Video Modes:"
VideoMode.get_video_modes.each { |mode| VideoMode.print_video_mode(mode)}
```

Partly a follow-up to:
- #11

Partly addressing aspects of:
- #18